### PR TITLE
PostgreSQL to MySQL query syntax mods

### DIFF
--- a/app/controllers/worktimelog_controller.rb
+++ b/app/controllers/worktimelog_controller.rb
@@ -64,7 +64,7 @@ class WorktimelogController < ApplicationController
     where_query = "issue_id = #{params[:issue_id]} AND flag = 1"
 
     if (params[:started] && params[:finished])
-      where_query += "AND (started, finished) OVERLAPS ('#{params[:started]}'::DATE, '#{params[:finished]}'::DATE)"
+      where_query += " AND (started >= '#{params[:started]}' AND finished <= '#{params[:finished]}')"
     end
 
     @summary = Worktimelog.joins([{issue: :project},:user]).select('
@@ -101,7 +101,7 @@ class WorktimelogController < ApplicationController
     where_query = "projects.identifier = '#{params[:project_id]}' AND flag = 1"
 
     if (params[:started] && params[:finished])
-      where_query += "AND (started, finished) OVERLAPS ('#{params[:started]}'::DATE, '#{params[:finished]}'::DATE)"
+      where_query += " AND (started >= '#{params[:started]}' AND finished <= '#{params[:finished]}')"
     end
 
     @summary = Worktimelog.joins([{issue: :project},:user]).select('
@@ -135,8 +135,8 @@ class WorktimelogController < ApplicationController
     @date = Time.now
     @where_query = "user_id = #{params[:id]} AND flag = 1"
     @user = User.find(params[:id])
-    if (params[:started] && params[:finished])
-      @where_query += "AND (started, finished) OVERLAPS ('#{params[:started]}'::DATE, '#{params[:finished]}'::DATE)"
+    if (params[:started] && params[:finished])  
+      @where_query += " AND (started >= '#{params[:started]}' AND finished <= '#{params[:finished]}')"    
     end
     @summary = Worktimelog.joins(issue: :project).select('
       issue_id,


### PR DESCRIPTION
Changed date-related query syntax in variable `where_query` from PostgreSQL to MySQL. Updated syntax should work on both platforms.
